### PR TITLE
fix: remove content margin when drawer is closed

### DIFF
--- a/src/fc-applayout.ts
+++ b/src/fc-applayout.ts
@@ -218,27 +218,60 @@ export class FcAppLayoutElement extends ThemableElement {
   }
 
   _updateMargin() {
+    let marginWidth = this.drawer.clientWidth + "px";
     if (this.drawerPersistent) {
-      let marginWidth = this.drawer.clientWidth + "px";
-      if (!this.drawer.opened) {
-        this.content.style.marginLeft = "0px";
-      }
-      if (!this.drawerBelowHeader) {
-        if (this.drawerAlign=="right") {
-          this.header.style.marginRight = marginWidth;
+      //TRUE TRUE
+      if(this.drawerBelowHeader){
+        if(this.drawer.opened) {
+          if (this.drawerAlign == "right") {
+            this.header.style.marginRight = "0px";
+            this.content.style.marginRight = marginWidth;
+          } else {
+            this.header.style.marginLeft = "0px";
+            this.content.style.marginLeft = marginWidth;
+          }
         } else {
-          this.header.style.marginLeft = marginWidth;
+          if (this.drawerAlign == "right") {
+            this.header.style.marginRight = "0px";
+            this.content.style.marginRight = "0px";
+          } else {
+            this.header.style.marginLeft = "0px";
+            this.content.style.marginLeft = "0px";
+          }
+        }
+      } else {//TRUE FALSE
+        if(this.drawer.opened) {
+          if (this.drawerAlign == "right") {
+            this.header.style.marginRight = marginWidth;
+            this.content.style.marginRight = marginWidth;
+          } else {
+            this.header.style.marginLeft = marginWidth;
+            this.content.style.marginLeft = marginWidth;
+          }
+        } else {
+          if (this.drawerAlign == "right") {
+            this.header.style.marginRight = "0px";
+            this.content.style.marginRight = "0px";
+          } else {
+            this.header.style.marginLeft = "0px";
+            this.content.style.marginLeft = "0px";
+          }
         }
       }
-      if (this.drawerAlign=="right") {
-        this.content.style.marginRight = marginWidth;
-      } else {
-        this.content.style.marginLeft = marginWidth;
+
+    } else {
+      //FALSE TRUE
+      //FALSE FALSE
+        if (this.drawerAlign == "right") {
+          this.header.style.marginRight = "0px";
+          this.content.style.marginRight = "0px";
+        } else {
+          this.header.style.marginLeft = "0px";
+          this.content.style.marginLeft = "0px";
+        }
       }
     }
   }
-
-}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
This PR fixes the margin of drawer and content. It works with the deafult left menu (drawerAlign="left"), but there are some bugs with the content when applayout is configured with drawerAlign="right".

To test this fix, in `dev/index.html` file, `<fc-applayout>` should be configured with all the following configuration combinations:
```
<fc-applayout draweralign="right" drawerbelowheader="" drawerpersistent="">
<fc-applayout draweralign="right" drawerpersistent="">
<fc-applayout draweralign="right" drawerbelowheader="">
<fc-applayout draweralign="right">

<fc-applayout draweralign="left" drawerbelowheader="" drawerpersistent="">
<fc-applayout draweralign="left" drawerpersistent="">
<fc-applayout draweralign="left" drawerbelowheader="">
<fc-applayout draweralign="left">
```